### PR TITLE
Built-in permissions, Customizable loghandling, backwards compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,33 +19,39 @@ plugins:
   - serverless-logstreaming
 ```
 
-2. Define permission for Cloudwatch to write to your loghandler:
-
-```
-resources:
-  # AWS CloudFormation Template
-  Resources:
-
-    # IAM
-    LoggingLambdaPermission:
-      Type: AWS::Lambda::Permission
-      Properties:
-        FunctionName:
-          Ref: LoghandlerLambdaFunction
-        Action: lambda:InvokeFunction
-        Principal: logs.amazonaws.com
-```
-
-3. If you don't already have a loghandler defined somewhere in your stack, do so.
+2. Define your loghandler function:
 
 ```
 functions:
-  loghandler:
+  myLogHandler:
     description: 'CW Logs handler for Tasks'
-    handler: handlers/loghandler/handler.handler
+    handler: handlers/myLogHandler/handler.handler
 ```
 
-And that's all it takes. Now the logs of all your lambda functions will stream through that loghandler
+3. Reference the name of your loghandler function in the custom section:
+
+```
+custom:
+  logHandler:
+    function: myLogHandler
+```
+
+And that's all it takes. Now the logs of all your lambda functions will stream through that loghandler.
+
+If you have a function where you _don't_ want to stream logs through the loghandler it's as simple as adding an exception:
+
+```
+functions:
+  handlerToNotStream:
+    description: 'This lambda should not stream logs'
+    loghandler: false
+```
+
+That `loghandler: false` will exempt this lambda from streaming through the loghandler function.
+
+## Changelog
+* 1.1.0 - Add logstreaming permission by default instead of requiring user to do so, add flexibility in naming
+* 1.0.0 - Initial commit.
 
 ## Acknowledgements
 * Thanks to @andymac4182 for the [gist](https://gist.github.com/andymac4182/4837f722231ea493685f6b4699c939a1) that inspired this plugin.

--- a/index.js
+++ b/index.js
@@ -29,21 +29,45 @@ class LogStreamingPlugin {
 	}
 
 	logServerless() {
+		let logHandlerLambdaName;
+		const logHandlerFnName = _.get(this.serverless, "service.custom.logHandler.function", "loghandler");
 		_.forEach(this.serverless.service.getAllFunctions(), functionName => {
-			if (functionName === "loghandler") {
+			const functionLogicalId = `${_.upperFirst(functionName)}LambdaFunction`;
+			if (functionName === logHandlerFnName) {
+				// Do not add the loghandler to itself.
+				logHandlerLambdaName = functionLogicalId;
 				return;
 			}
-			const functionLogicalId = `${_.upperFirst(functionName)}LambdaFunction`;
 			const functionObject = this.serverless.service.getFunction(functionName);
-
+			if (_.get(functionObject, "loghandler", true) === false) {
+				// If the loghandler property is set to false then do not create a loghandler
+				return;
+			}
 			cloudwatchLogsSubscriptionFilterTemplate.Properties.LogGroupName = `/aws/lambda/${functionObject.name}`;
 			const newResources = {
 				[`${functionLogicalId}SubscriptionFilter`]: cloudwatchLogsSubscriptionFilterTemplate
 			};
 
 			_.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, newResources);
-			
 		});
+		
+		if (!_.has(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, "LoggingLambdaPermission")) {
+			if (!logHandlerLambdaName || !logHandlerFnName) {
+				throw new Error("Loghandler plugin is not properly configured. Missing loghandler function definition.");
+			}
+			const loggingPermissions = {
+				["LoggingLambdaPermission"]: {
+					Type: "AWS::Lambda::Permission",
+					Properties: {
+						FunctionName: logHandlerLambdaName,
+						Action: "lambda:InvokeFunction",
+						Principal: "logs.amazonaws.com"
+					}
+				}
+			};
+			this.serverless.cli.log(`Adding 'LoggingLambdaPermission' to Resources with FunctionName ${logHandlerLambdaName}`);
+			_.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, loggingPermissions);
+		}
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ class LogStreamingPlugin {
 		let logHandlerLambdaName;
 		const logHandlerFnName = _.get(this.serverless, "service.custom.logHandler.function", "loghandler");
 		_.forEach(this.serverless.service.getAllFunctions(), functionName => {
-			const functionLogicalId = `${_.upperFirst(functionName)}LambdaFunction`;
+			const functionLogicalId = this.serverless.service.provider.naming.getLambdaLogicalId(functionName);
 			if (functionName === logHandlerFnName) {
 				// Do not add the loghandler to itself.
 				logHandlerLambdaName = functionLogicalId;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-logstreaming",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Serverless Logstreaming Plugin - Stream logs to the loghandler function",
   "main": "index.js",
   "author": "Michael Riffle",


### PR DESCRIPTION
This fixes Issue #1 
* Support `loghandler: false` in function definition to exclude function from logstreaming.
* Include permissions for loghandler in the plugin
* reference the function name from the `custom.logHandler.function` element, default to 'loghandler'

This change should be completely backwards compatible to any existing changes so we should be able to release as 1.1.0